### PR TITLE
fix: loading fields with null=True attribute

### DIFF
--- a/marshmallow_pynamodb/schema.py
+++ b/marshmallow_pynamodb/schema.py
@@ -109,20 +109,16 @@ class ModelSchema(Schema, metaclass=ModelMeta):
 
     def load(self, *args, **kwargs):
         """Override load to add pre-generated partial fields."""
-        data = args[0]
-        many = kwargs.pop("many", None)
         partial = kwargs.pop("partial", None)
-        if partial is not None:
+        if partial is not None and self.opts.partial_fields:
             if isinstance(partial, set):
                 partial = list(partial)
             if isinstance(partial, list):
                 partial += self.opts.partial_fields
-        else:
+        elif self.opts.partial_fields:
             partial = self.opts.partial_fields
-        unknown = kwargs.pop("unknown", None)
-        return self._do_load(
-            data, many=many, partial=partial, unknown=unknown, postprocess=True
-        )
+        kwargs["partial"] = partial
+        return super(ModelSchema, self).load(*args, **kwargs)
 
     def dump(self, obj: typing.Any, *args, **kwargs):
         """Serialize an object to native Python data types according to this Schema's fields."""

--- a/test/office_model.py
+++ b/test/office_model.py
@@ -37,6 +37,7 @@ class Location(MapAttribute):
     longitude = NumberAttribute()
     name = UnicodeAttribute()
     category = IntegerEnumAttribute(LocationCategory)
+    number_of_seats = NumberAttribute(null=True)
 
 
 class Person(MapAttribute):
@@ -65,6 +66,7 @@ class Office(Model):
     employees = ListAttribute(of=OfficeEmployeeMap)
     departments = UnicodeSetAttribute()
     numbers = NumberSetAttribute()
+    security_number = UnicodeAttribute(null=True)
 
 
 class Headquarters(Office):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,6 +1,5 @@
 import json
 from copy import deepcopy
-from datetime import datetime
 from uuid import UUID
 
 import pytest
@@ -55,22 +54,22 @@ def test_dump(data_attrs, data_dumps, freezer):
 
 
 @pytest.mark.freeze_time("2020-04-21")
-def test_dump_between_pynamo_and_model_schema(data_attrs, data_dumps, freezer):
+def test_dump_between_pynamo_and_model_schema(data_attrs, data_dumps):
     model_from_pynamo = Office(**data_attrs)
 
     payload = json.dumps(data_dumps)
     model_from_schema: Office = OfficeSchema().loads(payload)
 
+    assert (
+        model_from_pynamo.attribute_values.keys()
+        == model_from_schema.attribute_values.keys()
+    )
+
     model_from_pynamo.departments = sorted(model_from_pynamo.departments)
     model_from_schema.departments = sorted(model_from_schema.departments)
 
-    model_from_pynamo.employees[0]["start_date"] = datetime(2020, 4, 21, 12, 0, 0)
-    model_from_pynamo.employees[1]["start_date"] = datetime(2020, 4, 21, 12, 0, 0)
-    model_from_schema.employees[0]["start_date"] = datetime(2020, 4, 21, 12, 0, 0)
-    model_from_schema.employees[1]["start_date"] = datetime(2020, 4, 21, 12, 0, 0)
-
-    dump_from_pynamo = OfficeSchema().dumps(model_from_pynamo)
-    dump_from_schema = OfficeSchema().dumps(model_from_schema)
+    dump_from_pynamo = OfficeSchema().dump(model_from_pynamo)
+    dump_from_schema = OfficeSchema().dump(model_from_schema)
 
     assert dump_from_pynamo == dump_from_schema
 
@@ -93,4 +92,5 @@ def test_attributes_from_parent_models():
         "employees",
         "departments",
         "numbers",
+        "security_number",
     ]


### PR DESCRIPTION
When pynamodb attribute sets `null=True`
and payload does not have this attribute
Marshmallow will add automatically this
field to the `partial` list of fields