### PR TITLE
feat: Add support to ListAttribute without type

### DIFF
--- a/marshmallow_pynamodb/schema.py
+++ b/marshmallow_pynamodb/schema.py
@@ -59,15 +59,19 @@ class ModelMeta(SchemaMeta):
                         field = field(sub_model)
                     elif field == fields.List:
 
-                        class Meta:
-                            model = attribute.element_type
+                        if not attribute.element_type:
+                            field = field(fields.Raw)
+                        else:
 
-                        element_type = type(
-                            attribute.element_type.__name__,
-                            (ModelSchema,),
-                            {"Meta": Meta},
-                        )
-                        field = field(PynamoNested(element_type))
+                            class Meta:
+                                model = attribute.element_type
+
+                            element_type = type(
+                                attribute.element_type.__name__,
+                                (ModelSchema,),
+                                {"Meta": Meta},
+                            )
+                            field = field(PynamoNested(element_type))
                     elif field == EnumField:
                         field = field(attribute.enum_type, by_value=True)
                     else:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -65,6 +65,7 @@ def data_dumps():
         ],
         "numbers": [1, 2, 3, 4, 5, 6],
         "office_id": "18e430b0-a968-4c22-8b82-9735e94ca058",
+        "office_times": ["standard", 8, 17],
     }
 
 
@@ -118,4 +119,5 @@ def data_attrs():
         "departments": set(sorted(["engineering", "dev-ops", "UI/UX", "sales"])),
         "numbers": [1, 2, 3, 4, 5, 6],
         "office_id": uuid.UUID("18e430b0-a968-4c22-8b82-9735e94ca058"),
+        "office_times": ["standard", 8, 17],
     }

--- a/test/office_model.py
+++ b/test/office_model.py
@@ -67,6 +67,7 @@ class Office(Model):
     departments = UnicodeSetAttribute()
     numbers = NumberSetAttribute()
     security_number = UnicodeAttribute(null=True)
+    office_times = ListAttribute()
 
 
 class Headquarters(Office):


### PR DESCRIPTION
On Pynamo is valid to use: `foo = ListAttribute()` without defining type for list components.